### PR TITLE
Add interaction count to bar chart

### DIFF
--- a/simulation/Cargo.lock
+++ b/simulation/Cargo.lock
@@ -1098,6 +1098,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "human_format"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86cce260d758a9aa3d7c4b99d55c815a540f8a37514ba6046ab6be402a157cb0"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,9 +1898,12 @@ version = "0.1.0"
 dependencies = [
  "eframe",
  "egui",
+ "futures",
+ "human_format",
  "rand",
  "rstest",
  "thiserror",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2084,6 +2093,17 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+dependencies = [
+ "autocfg",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "toml_datetime"

--- a/simulation/Cargo.toml
+++ b/simulation/Cargo.toml
@@ -8,8 +8,11 @@ authors = ["Tom Groenwoldt <tom.groenwoldt@tuhh.de>"]
 [dependencies]
 eframe = "0.21.3"
 egui = "0.21.0"
+futures = "0.3.28"
+human_format = "1.0.3"
 rand = "0.8.5"
 rstest = "0.17.0"
 thiserror = "1.0.40"
+tokio = { version = "1.28.0", features = ["sync"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"

--- a/simulation/src/ui.rs
+++ b/simulation/src/ui.rs
@@ -1,10 +1,11 @@
-use egui::{
-    plot::{Bar, BarChart, Plot},
-    Color32,
-};
 use std::thread;
 
-use crate::{simulation::Simulation, App, State};
+use egui::plot::{Bar, BarChart, Legend, Plot};
+
+use crate::{
+    simulation::{Simulation, SimulationMessage},
+    App, State,
+};
 
 /// GUI implementation via egui and eframe.
 impl eframe::App for App {
@@ -16,30 +17,21 @@ impl eframe::App for App {
                 ui.add(
                     egui::Slider::new(&mut self.config.agent_count, 2..=100000000)
                         .text("Number of Agents")
-                        .logarithmic(true),
+                        .logarithmic(true)
+                        .trailing_fill(true),
                 );
                 ui.add(
-                    egui::Slider::new(&mut self.config.sample_size, 2..=255).text("Sample Size"),
+                    egui::Slider::new(&mut self.config.sample_size, 2..=255)
+                        .text("Sample Size")
+                        .trailing_fill(true),
                 );
                 ui.add(
                     egui::Slider::new(&mut self.config.opinion_count, 2..=10)
-                        .text("Number of Opinions"),
+                        .text("Number of Opinions")
+                        .trailing_fill(true),
                 );
-                if ui.button("Start simulation").clicked() {
-                    self.state = State::Simulation;
-
-                    // Execute the simulation on another thread.
-                    for sender in &self.senders {
-                        let sender = sender.clone();
-                        let config = self.config.clone();
-                        thread::spawn(move || {
-                            let mut simulation = Simulation::new(config, sender);
-                            simulation.execute().unwrap();
-                        });
-                    }
-                }
             });
-            egui::TopBottomPanel::bottom("opinion_distribution_configuration").show(ctx, |ui| {
+            egui::TopBottomPanel::top("opinion_distribution_configuration").show(ctx, |ui| {
                 ui.set_enabled(self.state.eq(&State::Config));
                 ui.heading("Opinion distribution");
                 ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
@@ -49,7 +41,8 @@ impl eframe::App for App {
                                 self.config.weights.entry(opinion).or_insert(1),
                                 0..=5,
                             )
-                            .vertical(),
+                            .vertical()
+                            .trailing_fill(true),
                         );
                     }
                     // Remove old opinion distribution entries. Otherwise a decrease in opinion
@@ -59,33 +52,59 @@ impl eframe::App for App {
                     }
                 });
             });
-            egui::CentralPanel::default().show(ctx, |ui| {
-                ui.set_enabled(self.state.eq(&State::Simulation));
+            egui::CentralPanel::default().show(ctx, |_ui| {
                 egui::TopBottomPanel::top("simulation_header").show(ctx, |ui| {
                     ui.heading("Simulation");
-                    let finished = self
-                        .simulations
-                        .iter()
-                        .all(|sim| sim.lock().unwrap().finished);
-                    ui.set_enabled(finished);
                     ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
-                        // ui.label(format!(
-                        //     "Number of interactions: {}",
-                        //     simulation.interaction_count
-                        // ));
-                        if ui
-                            .button("Simulations finished. Click to simulate again!")
-                            .clicked()
-                        {
-                            // Reset the simulations. This way we keep the communication with the
-                            // simulation thread open.
-                            for simulation in self.simulations.iter() {
-                                let mut simulation = simulation.lock().unwrap();
-                                simulation.opinion_distribution.clear();
-                                simulation.finished = false;
+                        ui.add_enabled_ui(self.state.eq(&State::Config), |ui| {
+                            if ui.button("Start").clicked() {
+                                self.state = State::Simulation;
+
+                                // Execute the simulation on another thread.
+                                for sender in &self.senders {
+                                    let sender = sender.clone();
+                                    let config = self.config.clone();
+                                    let receiver = self.broadcast.subscribe();
+                                    thread::spawn(move || {
+                                        let mut simulation = Simulation::new(config, sender);
+                                        simulation.execute(receiver).unwrap();
+                                    });
+                                }
                             }
-                            self.state = State::Config;
-                        }
+                        });
+                        ui.add_enabled_ui(self.state.eq(&State::Simulation), |ui| {
+                            let finished = self
+                                .simulations
+                                .iter()
+                                .all(|sim| sim.lock().unwrap().finished);
+                            ui.add_enabled_ui(!finished, |ui| {
+                                if ui.toggle_value(&mut self.paused, "Pause").clicked() {
+                                    match self.paused {
+                                        true => {
+                                            self.broadcast.send(SimulationMessage::Pause).unwrap()
+                                        }
+                                        false => {
+                                            self.broadcast.send(SimulationMessage::Play).unwrap()
+                                        }
+                                    };
+                                }
+                                if ui.button("Abort").clicked() {
+                                    self.broadcast.send(SimulationMessage::Abort).unwrap();
+                                }
+                            });
+                            ui.add_enabled_ui(finished, |ui| {
+                                if ui.button("Repeat").clicked() {
+                                    // Reset the simulations. This way we keep the communication with the
+                                    // simulation thread open.
+                                    for simulation in self.simulations.iter() {
+                                        let mut simulation = simulation.lock().unwrap();
+                                        simulation.opinion_distribution.clear();
+                                        simulation.finished = false;
+                                    }
+                                    self.state = State::Config;
+                                }
+                            });
+                        });
                     });
                 });
                 egui::CentralPanel::default().show(ctx, |ui| {
@@ -108,15 +127,18 @@ impl eframe::App for App {
                                 })
                                 .collect(),
                         )
-                        .color(Color32::WHITE);
+                        .name(self.formatter.format(simulation.interaction_count as f64));
+
                         charts.push(chart);
                     }
 
-                    Plot::new("chart").show(ui, |plot_ui| {
-                        for chart in charts {
-                            plot_ui.bar_chart(chart);
-                        }
-                    });
+                    Plot::new("chart")
+                        .legend(Legend::default().background_alpha(1.0))
+                        .show(ui, |plot_ui| {
+                            for chart in charts {
+                                plot_ui.bar_chart(chart);
+                            }
+                        });
                 });
             });
         });


### PR DESCRIPTION
This PR adds the interaction count via a legend to all active charts. Sometimes not all interactions counts are rendered. I also reworked a bit of the GUI buttons and added human readable numbers for the interaction counts.