### PR TITLE
Support dynamic number of simulations and add average interaction count

### DIFF
--- a/simulation/src/config.rs
+++ b/simulation/src/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
     pub sample_size: u8,
     pub opinion_count: u8,
     pub weights: HashMap<u8, u8>,
+    pub simulation_count: u8,
 }
 
 impl Default for Config {
@@ -15,6 +16,7 @@ impl Default for Config {
             sample_size: 2,
             opinion_count: 2,
             weights: HashMap::new(),
+            simulation_count: 1,
         }
     }
 }

--- a/simulation/src/simulation.rs
+++ b/simulation/src/simulation.rs
@@ -261,6 +261,7 @@ mod simulation {
             sample_size: 5,
             opinion_count: 1,
             weights: HashMap::new(),
+            simulation_count: 1,
         };
         let mut simulation = Simulation::new(config, sender());
         simulation.execute(receiver())?;
@@ -279,6 +280,7 @@ mod simulation {
             sample_size: 2,
             opinion_count,
             weights: HashMap::new(),
+            simulation_count: 1,
         };
         let mut simulation = Simulation::new(config, sender());
         simulation.execute(receiver())?;

--- a/simulation/src/ui/config.rs
+++ b/simulation/src/ui/config.rs
@@ -21,6 +21,11 @@ pub fn render_config(ui: &mut Ui, app: &mut App) {
             .text("Number of Opinions")
             .trailing_fill(true),
     );
+    ui.add(
+        egui::Slider::new(&mut app.config.simulation_count, 1..=100)
+            .text("Number of Simulations")
+            .trailing_fill(true),
+    );
 }
 
 pub fn render_opinion_distribution_config(ui: &mut Ui, app: &mut App) {


### PR DESCRIPTION
This PR adds a configuration slider, which lets the user execute multiple simulations in parallel.

I also added an average interaction count. Having the individual interaction counts inside a legend overflowed when executing many simulations.